### PR TITLE
Bootstrap with PuppetLabs repo instead of default Ubuntu

### DIFF
--- a/lib/supply_drop/tasks.rb
+++ b/lib/supply_drop/tasks.rb
@@ -37,6 +37,21 @@ Capistrano::Configuration.instance.load do
         run "mkdir -p #{puppet_destination}"
         run "#{sudo} yum -y install puppet rsync"
       end
+
+      namespace :puppetlabs do
+
+        desc "setup the puppetlabs repo, then install via the normal method"
+        task :ubuntu do
+          run "echo deb http://apt.puppetlabs.com/ $(lsb_release -sc) main | #{sudo} tee /etc/apt/sources.list.d/puppet.list"
+          run "#{sudo} apt-key adv --keyserver keyserver.ubuntu.com --recv 4BD6EC30"
+          puppet.bootstrap.ubuntu
+        end
+
+        desc "setup the puppetlabs repo, then install via the normal method"
+        task :redhat do
+          logger.info "PuppetLabs::RedHat bootstrap is not implemented yet"
+        end
+      end
     end
 
     desc "checks the syntax of all *.pp and *.erb files"


### PR DESCRIPTION
I found myself always creating a capistrano task to setup the PuppetLabs repo prior to running bootstrap.  I finally decided that it would be nice to just include that functionality in the bootstrap process itself.  This addition simply adds a namespace within puppet:bootstrap.  Once the PuppetLabs repo, and gpg key, have been added the normal puppet:bootstrap:ubuntu method is invoked.

I only use Ubuntu and am not comfortable trying to be the "official implementation" of this for the redhat.  I would really like for someone to implement that task.  I currently have the redhat task log a "not implemented" message.

Old way: cap puppet:bootstrap:ubuntu
New way:  cap puppet:bootstrap:puppetlabs:ubuntu

Note:
As I was writing this it occurred to me that perhaps a better way would be to re-implement the ubuntu task as a namespace with a default task to install via the Ubuntu repositories and an additional task to install via the PuppetLabs repo.

Ubuntu repo:  cap puppet:bootstrap:ubuntu
PL repo:  cap puppet:bootstrap:ubuntu:puppetlabs

I am interested in some feedback on either method and can implement the second way that I noted if necessary.
