### PR TITLE
need to include puppetlabs dependancies repo

### DIFF
--- a/lib/supply_drop/tasks.rb
+++ b/lib/supply_drop/tasks.rb
@@ -43,6 +43,7 @@ Capistrano::Configuration.instance.load do
         desc "setup the puppetlabs repo, then install via the normal method"
         task :ubuntu do
           run "echo deb http://apt.puppetlabs.com/ $(lsb_release -sc) main | #{sudo} tee /etc/apt/sources.list.d/puppet.list"
+          run "echo deb http://apt.puppetlabs.com/ $(lsb_release -sc) dependancies | #{sudo} tee -a /etc/apt/sources.list.d/puppet.list"
           run "#{sudo} apt-key adv --keyserver keyserver.ubuntu.com --recv 4BD6EC30"
           puppet.bootstrap.ubuntu
         end


### PR DESCRIPTION
otherwise failes due to no ruby-rgen available.

apt-get install puppet-common
Reading package lists... Done
Building dependency tree  
Reading state information... Done
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 puppet-common : Depends: ruby-rgen (>= 0.6.5) but it is not installable
                 Recommends: debconf-utils but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
