### PR TITLE
Fixes bundle exec startup error when not using capistrano

### DIFF
--- a/lib/supply_drop.rb
+++ b/lib/supply_drop.rb
@@ -3,15 +3,3 @@ require 'supply_drop/async_enumerable'
 require 'supply_drop/thread_pool'
 require 'supply_drop/util'
 require 'supply_drop/tasks'
-
-set :puppet_source, '.'
-set :puppet_destination, '/var/tmp/supply_drop'
-set :puppet_command, 'puppet apply'
-set :puppet_lib, lambda { "#{fetch(:puppet_destination)}/modules" }
-set :puppet_parameters, lambda { fetch(:puppet_verbose) ? '--debug --trace --color false puppet.pp' : '--color false puppet.pp' }
-set :puppet_verbose, false
-set :puppet_excludes, %w(.git .svn)
-set :puppet_parallel_rsync, true
-set :puppet_parallel_rsync_pool_size, 10
-set :puppet_runner, nil
-set :puppet_lock_file, '/tmp/puppet.lock'

--- a/lib/supply_drop/tasks.rb
+++ b/lib/supply_drop/tasks.rb
@@ -1,6 +1,20 @@
-namespace :puppet do
+namespace :load do
   task :defaults do
+    set :puppet_source, '.'
+    set :puppet_destination, '/var/tmp/supply_drop'
+    set :puppet_command, 'puppet apply'
+    set :puppet_lib, lambda { "#{fetch(:puppet_destination)}/modules" }
+    set :puppet_parameters, lambda { fetch(:puppet_verbose) ? '--debug --trace --color false puppet.pp' : '--color false puppet.pp' }
+    set :puppet_verbose, false
+    set :puppet_excludes, %w(.git .svn)
+    set :puppet_parallel_rsync, true
+    set :puppet_parallel_rsync_pool_size, 10
+    set :puppet_runner, nil
+    set :puppet_lock_file, '/tmp/puppet.lock'
   end
+end
+
+namespace :puppet do
 
   namespace :bootstrap do
     desc "installs puppet via rubygems on an osx host"


### PR DESCRIPTION
Attempting to run rake tasks e.g. bundle exec rake secret fails because supply drop attempts to load the defaults directly within the main file with set. Outside of capistrano's framework set is not recognized so it fails with error: 'undefined method set for main:Object'. Loading the defaults within the tasks file via load:defaults (capistrano hook) is best practice and fixes this issue.

Major issue for people who need to run rake tasks locally.
