### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ or with Bundler
 
     gem 'supply_drop'
 
-then at the top of your deploy.rb
+then add the following to your Capfile
 
     require 'supply_drop'
 


### PR DESCRIPTION
Adding the require statement to the `deploy.rb` file creates an error where the load:defaults task is not run and defaults do not get set.