### PR TITLE
Fix Gemspec Loading Issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,2 @@
 source 'https://rubygems.org'
 gemspec
-
-# Required for Travis CI
-gem 'rake', '>=10.0.0'

--- a/supply_drop.gemspec
+++ b/supply_drop.gemspec
@@ -1,5 +1,3 @@
-require 'rake'
-
 Gem::Specification.new do |s|
   s.name = "supply_drop"
   s.summary = "Masterless puppet with capistrano"
@@ -9,6 +7,7 @@ Gem::Specification.new do |s|
   s.email = ["tony.pitluga@gmail.com", "paul.t.hinze@gmail.com"]
   s.homepage = "http://github.com/pitluga/supply_drop"
   s.license = "MIT"
-  s.files = FileList["README.md", "Rakefile", "lib/**/*.rb"]
+  s.files = ['README.md', 'Rakefile'] + Dir['lib/**/*.rb']
   s.add_dependency('capistrano', '>= 3.0.1', '< 4.0.0')
+  s.add_development_dependency 'rake'
 end


### PR DESCRIPTION
When my application runs on CircleCI I occasionally get an error that looks like the following:

```
There was a LoadError while loading supply_drop.gemspec: 
cannot load such file -- rake from
/home/ubuntu/supply_drop_test/vendor/bundle/ruby/2.3.0/bundler/gems/supply_drop-d64c50c1e658/supply_drop.gemspec:1:in
`<main>'
```

The usage of Rake in a gemspec is not unusual. In fact the rubygem spec even [recommends it](http://guides.rubygems.org/specification-reference/#files) as an option. The error doesn't make much sense as obviously `rake` should be found since is included with Ruby. This issue seemed to come about when I upgraded to a newer version of Ruby (2.3.1).

What I think is happening is that CircleCI is installing the right version of Ruby and gems requested but that the bundle check it is doing is still running under the version of Ruby that was previously there from the cache or if no cache then their default version of Ruby. I think there an incompatibility between the slightly older version of ruby and the newer version of the rake library causing it to fail to load.

In an attempt to confirm all this I created a [demo repo](https://github.com/eric1234/supply_drop_test) that tries to be the simplest repeatable setup I could. If I [made it use an older ruby (2.5.1)](https://github.com/eric1234/supply_drop_test/commit/409f78bc8fef0141beda8e09f9234380d7c7ce96) I never get the issue (I think because the rake with that version is compatible with the default ruby binary on CircleCI), but when I use [2.3.0](https://github.com/eric1234/supply_drop_test/commit/a3dd6aa8f61025e58e07548cef7b9837f4553b45) or [2.3.1](https://github.com/eric1234/supply_drop_test/commit/c2ab5820754a5a035886c125b020341fafa9334e) I can consistently get the issue anytime I re-build without the cache. In my application I also sometimes get it even with the cache as the test starts to execute although I couldn't duplicate that in my demo repo.

This all may be fundamentally a CircleCI issue (I'm going to refer this ticket to them so they can investigate on their end if they wish) but to make supply_drop not susceptible to this issue I am creating a commit that removes the rake dependency completely and instead just relies on simpler built-in primitives (namely `Dir[]`).
