### PR TITLE
Add support for rsync include flag

### DIFF
--- a/lib/capistrano/supply_drop/rsync.rb
+++ b/lib/capistrano/supply_drop/rsync.rb
@@ -7,6 +7,7 @@ module SupplyDrop
 
         # --delete will remove files on 'to' that don't exist on 'from'
         flags = ['-az', '--delete']
+        flags << [options[:includes]].flatten.compact.map { |p| "--include=#{p}" }
         flags << [options[:excludes]].flatten.compact.map { |p| "--exclude=#{p}" }
         flags << ssh_options(options[:ssh])
 

--- a/lib/capistrano/tasks/supply_drop.rake
+++ b/lib/capistrano/tasks/supply_drop.rake
@@ -8,6 +8,7 @@ namespace :load do
     set :puppet_parameters, lambda { fetch(:puppet_verbose) ? '--debug --trace --color false puppet.pp' : '--color false puppet.pp' }
     set :puppet_verbose, false
     set :puppet_excludes, %w(.git .svn)
+    set :puppet_includes, %w()
     set :puppet_parallel_rsync, true
     set :puppet_parallel_rsync_pool_size, 10
     set :puppet_runner, nil
@@ -171,6 +172,7 @@ namespace :puppet do
         fetch(:puppet_source),
         fetch(:puppet_destination),
         :excludes => fetch(:puppet_excludes),
+        :includes => fetch(:puppet_includes),
         :ssh      => fetch(:ssh_options, {}).merge(server.ssh_options||{}).merge(overrides)
       )
       info rsync_cmd

--- a/test/rsync_test.rb
+++ b/test/rsync_test.rb
@@ -21,6 +21,11 @@ class RsyncTest < Test::Unit::TestCase
     assert_equal 'rsync -az --delete --exclude=.git bar foo', command
   end
 
+  def test_allows_specifying_an_include
+    command = SupplyDrop::Rsync.command('bar', 'foo', :includes => 'secrets/staging')
+    assert_equal 'rsync -az --delete --include=secrets/staging bar foo', command
+  end
+
   def test_ssh_options_keys_only_lists_existing_files
     command = SupplyDrop::Rsync.command('.', 'foo', :ssh => { :keys => [__FILE__, "#{__FILE__}dadijofs"] })
     assert_match /-i '#{__FILE__}'/, command


### PR DESCRIPTION
Currently support for the rsync include flag is not provided via supply drop. This PR adds this support. The reason for this support is so you can explicitly include some nested folders while excluding others for example if you want to include a select list of secret files.

Special note: The include flag should come before the exclude flag so rsync does not throw out the included files before they can have a chance to be included.
